### PR TITLE
[Feat] 전역 예외 처리 및 API 공통 응답 포맷 구현 (#12)

### DIFF
--- a/src/main/java/com/umc/apiwiki/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/ApiResponse.java
@@ -1,0 +1,36 @@
+package com.umc.apiwiki.global.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.umc.apiwiki.global.apiPayload.code.BaseErrorCode;
+import com.umc.apiwiki.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    @JsonProperty("code")
+    private final String code;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("result")
+    private T result;
+
+    // 성공한 경우 (결과 포함)
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+    // 실패한 경우 (결과 포함)
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
+    }
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.umc.apiwiki.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/code/BaseSuccessCode.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package com.umc.apiwiki.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,31 @@
+package com.umc.apiwiki.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode{
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,
+            "COMMON400",
+            "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,
+            "COMMON401",
+            "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,
+            "COMMON403",
+            "금지된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "COMMON404",
+            "요청한 리소스를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
+            "COMMON500",
+            "서버 에러, 관리자에게 문의 바랍니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,22 @@
+package com.umc.apiwiki.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode{
+
+    OK(HttpStatus.OK,
+            "COMMON200",
+            "성공입니다."),
+    CREATED(HttpStatus.CREATED,
+            "COMMON201",
+            "생성 성공입니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/exception/GeneralException.java
@@ -1,0 +1,12 @@
+package com.umc.apiwiki.global.apiPayload.exception;
+
+import com.umc.apiwiki.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private final BaseErrorCode code;
+}

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,0 +1,42 @@
+package com.umc.apiwiki.global.apiPayload.handler;
+
+import com.umc.apiwiki.global.apiPayload.ApiResponse;
+import com.umc.apiwiki.global.apiPayload.code.BaseErrorCode;
+import com.umc.apiwiki.global.apiPayload.code.GeneralErrorCode;
+import com.umc.apiwiki.global.apiPayload.exception.GeneralException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GeneralExceptionAdvice {
+
+    // 애플리케이션에서 발생하는 커스텀 예외를 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(
+            GeneralException ex
+    ) {
+
+        return ResponseEntity.status(ex.getCode().getStatus())
+                .body(ApiResponse.onFailure(
+                                ex.getCode(),
+                                null
+                        )
+                );
+    }
+
+    // 그 외의 정의되지 않은 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleException(
+            Exception ex
+    ) {
+
+        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(
+                                code,
+                                ex.getMessage()
+                        )
+                );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closed #12

## #️⃣ 작업 내용

프론트엔드와의 협업 효율성을 높이기 위해 **API 공통 응답 포맷**을 정의하고, **전역 예외 처리기**를 도입했습니다.

1. **공통 응답 DTO (`ApiResponse<T>`) 구현**: 성공 및 실패 응답 형식을 통일했습니다.
2. **GlobalExceptionHandler 구현**: `@RestControllerAdvice`를 사용하여 런타임 예외를 전역적으로 캐치하고 표준 포맷으로 변환합니다.
3. **Status Code 관리 전략 수립**:
  * **에러 코드**: `GeneralErrorCode`에 도메인별 에러(예: `USER4001`)를 추가하여 관리합니다.
  * **성공 코드**: 복잡도를 줄이기 위해 아래 **두 가지 상태만 사용**합니다.
    * `OK` (200, "COMMON200")
    * `CREATED` (201, "COMMON201")

## #️⃣ 테스트 결과

* **로컬 테스트 완료**: 임시 컨트롤러(`TempController`)를 생성하여 Postman으로 테스트를 진행했습니다.
* **성공 케이스**: 200 OK 및 201 Created 응답이 `ApiResponse` 포맷으로 정상 반환됨을 확인했습니다.
* **실패 케이스**: 의도적인 예외 발생 시 `GlobalExceptionHandler`가 가로채어 에러 코드를 포함한 JSON을 반환함을 확인했습니다.
* (테스트 완료 후 임시 컨트롤러 코드는 제거하였습니다.)

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (로컬 수동 테스트)
* [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

* 성공 응답 반환 
<img width="521" height="187" alt="스크린샷 2026-01-07 165843" src="https://github.com/user-attachments/assets/dae23b83-f355-4261-ab8f-10c3decac013" />

* 실패 응답 반환
<img width="512" height="223" alt="스크린샷 2026-01-07 170002" src="https://github.com/user-attachments/assets/2752095e-bd13-414c-bd94-390336a0ef43" />

## #️⃣ 리뷰 요구사항 (선택)

**[팀원 필독 사항]**
앞으로 모든 컨트롤러는 **`ApiResponse`를 반환 타입으로 사용**해주세요.

**1. 에러 코드 추가 시**
`GeneralErrorCode` Enum에 본인이 필요한 도메인과 HTTP 상태 코드를 매핑해서 추가해주시면 됩니다.

**2. 성공 코드 사용 시**
성공 코드는 기능별로 만들지 않고 아래 **2가지만 사용**하겠습니다。

```java
OK(HttpStatus.OK, "COMMON200", "성공입니다."),
CREATED(HttpStatus.CREATED, "COMMON201", "생성 성공입니다.")
```
