### PR TITLE
[Refactor] 배포 안정성을 위한 Systemd 서비스 도입 및 스크립트 고도화 (#19)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          # Secrets 값을 환경변수로 주입하여 스크립트 실행
-          envs: DB_HOST,DB_USERNAME,DB_PASSWORD
           script: |
             export DB_HOST=${{ secrets.DB_HOST }}
             export DB_USERNAME=${{ secrets.DB_USERNAME }}
             export DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            export DNS=${{ secrets.SENTRY_DSN }}
+            chmod +x /home/ubuntu/deploy.sh
             /home/ubuntu/deploy.sh


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #19

## #️⃣ 작업 내용

**1. 문제 상황 및 원인 분석**
기존 `nohup`과 쉘 스크립트(`kill` + `sleep`) 방식의 배포에서 타이밍 이슈로 인해 포트 충돌이 발생하여 서버가 중단되는 사고가 있었습니다. 프로세스 관리를 스크립트의 `sleep`에 의존하는 것은 불안정하다고 판단하여, 리눅스 표준 서비스 관리 도구인 **Systemd**로 이관하였습니다.

**2. Systemd 도입 이유 (vs Nohup)**
  * **프로세스 관리의 안정성:** `nohup`은 단순히 백그라운드 실행만 시키지만, `Systemd`는 OS 레벨에서 프로세스의 생명주기를 관리합니다. (확실한 종료 후 실행 보장)
  * **자동 재시작(Auto Restart):** 애플리케이션이 예기치 않게 종료(Crash)되더라도 `Systemd`가 이를 감지하여 자동으로 재시작합니다.
  * **환경변수 관리:** GitHub Secrets 값을 파일(`.env`)로 관리하여, 서비스 실행 시 안전하게 주입할 수 있습니다.
  * **로그 관리:** 비대해지는 `nohup.out` 대신 `journalctl`을 통해 체계적인 로그 관리가 가능합니다.
 
**3. 상세 변경 내역**
  * **GitHub Actions (`main.yml`)**: `script` 단계에서 DB 정보 및 `SENTRY_DSN` 등 Secrets 값을 명시적으로 `export` 하도록 수정.
  * **배포 스크립트 (`deploy.sh`)**:
    * 불확실한 `kill` 로직 삭제.
    * 환경변수를 `/home/ubuntu/build/app.env` 파일로 추출하는 로직 추가.
    * `sudo systemctl restart apiwiki` 명령어로 서비스 재시작 위임.
 
  * **Systemd 설정 파일 (`apiwiki.service`)**:
     * EC2 내 `/etc/systemd/system/` 경로에 서비스 파일 생성.
    * `EnvironmentFile` 옵션으로 `.env` 파일 로드 설정.
    * 실행 명령(`ExecStart`)에 `-D` 옵션으로 환경변수 바인딩.

## #️⃣ 테스트 결과

* **배포 테스트:** GitHub Actions 재실행 결과 정상 배포 확인.
* **서비스 상태:** EC2 터미널에서 `systemctl status apiwiki` 확인 시 `Active: active (running)` 상태 확인.
* **환경변수:** 애플리케이션 구동 로그 확인 결과 DB 연결 및 Sentry 연동 정상 작동 확인.
* **포트 점유:** 재배포 시 포트 충돌 에러 없이 기존 프로세스 종료 후 정상 구동됨.

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (배포 스크립트 테스트 완료)
* [x] 문서를 작성하거나 수정했나요? (PR 본문으로 대체)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요? (환경변수 의존성 해결)

## #️⃣ 리뷰 요구사항 (선택)

* `deploy.sh`에서 환경변수 파일을 생성하는 부분이 보안상 문제는 없을지, 혹은 더 나은 방법이 있을지 의견 있으시다면 말씀해주세요!
* 향후 무중단 배포(Blue/Green) 도입 전까지 이 방식이 안정적일지 검토 부탁드립니다.
* 추가적으로 새 코드가 main에 merge되고 난 이후 서버가 작동 중에 있는지 매번 확인 부탁드립니다!
  * 서버 작동 확인 경로 : `https://apiwiki-api.my-project.cloud/health`

## 📎 참고 자료 (선택)

* [Systemd 공식 문서](https://www.freedesktop.org/wiki/Software/systemd/)