### PR TITLE
[fix] 운영 환경에서 H2 Console 설정 오류로 인한 SecurityConfig 로드 실패 해결 (#21)

### DIFF
--- a/src/main/java/com/umc/apiwiki/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/apiwiki/global/config/SecurityConfig.java
@@ -1,15 +1,16 @@
 package com.umc.apiwiki.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
-import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration
 @EnableWebSecurity
@@ -17,46 +18,31 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
-        // H2 Console이 켜져있을 경우를 대비한 MvcRequestMatcher
-        // (스프링 부트 3.x부터는 H2 콘솔 제어 시 Introspector를 사용하는 것이 권장됨)
-        MvcRequestMatcher h2RequestMatcher = new MvcRequestMatcher(introspector, "/**");
-        h2RequestMatcher.setServletPath("/h2-console");
-
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // 1. CSRF 비활성화
-                .csrf((csrf) -> csrf
-                        .disable()
-                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
 
-                // 2. Form & Basic 인증 비활성화
-                .formLogin((auth) -> auth.disable())
-                .httpBasic((auth) -> auth.disable())
-
-                // 3. 요청 권한 설정 (핵심 변경 포인트)
-                .authorizeHttpRequests((auth) -> auth
-                        // [안전 장치] H2 콘솔 요청은 "spring.h2.console.enabled = true" 일 때만 허용
-                        .requestMatchers(PathRequest.toH2Console()).permitAll()
-
-                        // Swagger 및 헬스 체크 허용
+                .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/health", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        // 그 외 모든 요청은 인증된 사용자만 접근 가능 (지금은 로그인 기능 없으니 사실상 다 막힘)
                         .anyRequest().authenticated()
                 )
 
-                // 4. X-Frame-Options 설정 (보안을 위해 필요)
-                .headers((headers) -> headers
-                        .frameOptions((frame) -> {
-                            // 배포 환경에서 H2 콘솔을 아예 안 쓴다면 sameOrigin()을 써서 보안을 지킴
-                            // 로컬에서만 frame.disable() 효과를 내기 위해 로직 분기 불필요 (H2 요청에 대해서만 예외처리)
-                            frame.sameOrigin();
-                        })
-                )
-
-                // 5. 세션 설정
-                .sessionManagement((session) -> session
+                .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         return http.build();
+    }
+
+    /**
+     * 로컬 H2 접근 관련 문제 해결책: WebSecurityCustomizer
+     * spring.h2.console.enabled = true 인 경우에만(즉 로컬에서만) 이 빈이 생성
+     */
+    @Bean
+    @ConditionalOnProperty(name = "spring.h2.console.enabled", havingValue = "true")
+    public WebSecurityCustomizer configureH2ConsoleEnable() {
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toH2Console());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

closes #21

## #️⃣ 작업 내용

**운영 환경(Prod)과 로컬 환경(Local)의 DB 차이로 인해 발생하는 Security 설정 오류를 수정했습니다.**

**1. 문제 상황 (Trouble)**
* 기존 `SecurityConfig` 내부의 `PathRequest.toH2Console()` 코드는 H2 DB가 없는 운영 환경(RDS 사용)에서 빈 생성 에러를 유발했습니다.
* 이로 인해 `SecurityConfig` 로드가 실패하고, 스프링 시큐리티가 기본 차단 정책(Default)으로 동작하여 `/health` 경로까지 500 에러가 발생했습니다.

**2. 해결 방법: 조건부 WebSecurityCustomizer 적용 (`@ConditionalOnProperty`)**
* 기존의 복잡한 설정을 제거하고, `WebSecurityCustomizer` 빈에 `@ConditionalOnProperty`를 적용하여 환경별로 분리했습니다.
* **작동 원리 및 이점:**
  * **조건부 빈 생성:** `spring.h2.console.enabled = true` 인 경우에만(즉, 로컬에서만) 이 빈이 생성되도록 제한했습니다. 운영 환경에서는 로직이 아예 실행되지 않아 안전합니다.
  * **필터 체인 프리패스 (Filter Chain Bypass):** 이 빈이 생성되면 `/h2-console/**` 경로로 들어오는 요청은 스프링 시큐리티의 검문소(Filter Chain)를 아예 거치지 않고 바로 H2 서블릿으로 직행합니다.
  * **헤더 문제 자동 해결:** 검문소를 거치지 않으니, 스프링 시큐리티가 보안을 위해 강제로 붙이던 `X-Frame-Options: DENY` 헤더도 붙지 않습니다. 따라서 기존에 필요했던 `headers().frameOptions().sameOrigin()` 설정 없이도 화면이 정상적으로 뜨게 됩니다.

## #️⃣ 테스트 결과

* [x] **Prod (EC2):** 배포 후 `/health` 경로 접속 시 `I'm alive!!!` 정상 응답 확인. (보안 설정 정상 로드됨)
* [x] **Local:** `application.yml`에 H2 옵션 활성화 후 구동 시, `/h2-console` 접속 및 로그인 화면 정상 출력 확인.

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (로컬/운영 접속 테스트 완료)
* [x] 문서를 작성하거나 수정했나요? (이슈 및 PR 작성)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

**1. 운영 환경 (Prod) - Security 정상 로드 및 서버 정상 구동**
<img width="436" height="119" alt="image" src="https://github.com/user-attachments/assets/d7f5bff5-8732-4c42-8347-098ca6c75d71" />

**2. 로컬 환경 (Local) - H2 Console 보안 필터 우회 및 정상 접속**
<img width="628" height="268" alt="image" src="https://github.com/user-attachments/assets/5cbe8089-0a02-425c-9519-59e214eb1796" />

## 📎 참고 자료 (선택)

* `@ConditionalOnProperty`: 특정 프로퍼티 값에 따라 빈 등록 여부를 결정하는 스프링 부트 어노테이션.
* `WebSecurityCustomizer`: 스프링 시큐리티 필터 체인 자체를 생략(ignoring)하게 만드는 인터페이스.
