### PR TITLE
[Fix] Spring Boot 3.4 호환성 문제로 인한 Swagger 500 에러 해결 (#27)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     // annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     // annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-    // 6. Swagger (SpringDoc OpenAPI - 스프링 부트 3.x용)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    // 6. Swagger (SpringDoc OpenAPI - 스프링 부트 3.4와 호완을 위해 2.7 이상을 사용)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
     // 7. 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closed #27

## #️⃣ 작업 내용

**Swagger 500 에러(NoSuchMethodError) 해결을 위한 의존성 버전 업그레이드**
* **문제 원인**: 현재 프로젝트의 Spring Boot 버전(`3.4.2`)과 기존 SpringDoc 라이브러리 버전(`2.3.0`) 간의 호환성 문제 발생. (Spring Boot 3.4 내부 로직 변경으로 인해 구버전 라이브러리가 존재하지 않는 메서드를 호출)
* **해결 방안**: `build.gradle`의 `springdoc-openapi-starter-webmvc-ui` 버전을 `2.3.0`에서 **`2.8.3`**으로 업그레이드하여 호환성 문제 해결.

## #️⃣ 테스트 결과

* **로컬 빌드 확인**: `./gradlew clean build` 정상 수행 확인
* **서버 구동 확인**: 애플리케이션 정상 실행 확인
* **Swagger 접속 테스트**: `http://localhost:8080/swagger-ui/index.html` 접속 시 500 에러 없이 API 명세서가 정상적으로 로드됨을 확인 (아래 스크린샷 참조)

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (로컬 구동 테스트 완료)
* [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

**[Before] 수정 전 (500 에러 발생)**
<img width="1823" height="914" alt="스크린샷 2026-01-16 162138" src="https://github.com/user-attachments/assets/b6286b2b-589a-4888-a3c2-5020dee9c90f" />

**[After] 수정 후 (정상 접속)**
<img width="828" height="448" alt="image" src="https://github.com/user-attachments/assets/906ee209-273e-4558-808f-4beaa0806c24" />

## #️⃣ 리뷰 요구사항 (선택)

**⚠️ Gradle 리로드 필요**
`build.gradle`의 의존성 버전이 변경되었습니다.
이 PR을 Pull 받은 후에는 반드시 **코끼리 버튼(Load Gradle Changes)**을 눌러 라이브러리를 최신화해주세요!
배포 서버에서도 정상 작동하는지 확인 부탁드립니다.

## 📎 참고 자료 (선택)

* SpringDoc 공식 문서 호환성 가이드
