### PR TITLE
[Fix] 존재하지 않는 API 경로로 요청 시500 Internal Server Error가 반환되는 문제 해결 (#29)

### DIFF
--- a/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/code/GeneralErrorCode.java
@@ -19,7 +19,7 @@ public enum GeneralErrorCode implements BaseErrorCode{
             "금지된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND,
             "COMMON404",
-            "요청한 리소스를 찾을 수 없습니다."),
+            "요청한 리소스를 찾을 수 없습니다. 해당 경로는 존재하지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
             "COMMON500",
             "서버 에러, 관리자에게 문의 바랍니다."),

--- a/src/main/java/com/umc/apiwiki/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/apiwiki/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -8,6 +8,7 @@ import io.sentry.Sentry;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GeneralExceptionAdvice {
@@ -24,6 +25,16 @@ public class GeneralExceptionAdvice {
                                 null
                         )
                 );
+    }
+
+    // 경로 없음(404) 예외 처리
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException ex) {
+        // 404 에러는 Sentry에 보내지 않음 (로그 노이즈 방지)
+
+        BaseErrorCode code = GeneralErrorCode.NOT_FOUND;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, null));
     }
 
     // 그 외의 정의되지 않은 모든 예외 처리


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closed #29

## #️⃣ 작업 내용

**존재하지 않는 경로 요청 시 500 에러 반환 문제 수정**
* **문제 원인**: Spring Boot 3.x부터 도입된 `NoResourceFoundException`에 대한 별도 핸들러가 없어, `GlobalExceptionHandler`의 `Exception` 핸들러가 이를 포착해 500(Internal Server Error)을 반환하고 Sentry에 에러를 전송함.
* **해결 방안**: `GeneralExceptionAdvice`에 `NoResourceFoundException` 전용 핸들러를 추가하여, 해당 예외 발생 시 **404 Not Found** 상태 코드를 반환하도록 수정.
* **추가 효과**: 단순 경로 에러(404)가 Sentry 이슈로 등록되지 않도록 제외하여 에러 모니터링 노이즈 제거.

## #️⃣ 테스트 결과

* **수정 전**: 존재하지 않는 경로(`/api/unknown`) 요청 시 -> **500 Status** 반환, GlitchTip 알림 발생.
* **수정 후**: 존재하지 않는 경로(`/api/unknown`) 요청 시 -> **404 Status** 반환, 정상적인 에러 응답 JSON 확인.

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (API 요청 테스트 완료)
* [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

<img width="687" height="120" alt="image" src="https://github.com/user-attachments/assets/b6cafa6f-1fa0-45c8-aa5d-8f950b9d0748" />


## 📎 참고 자료 (선택)

> Spring Framework 6.1 `NoResourceFoundException` 문서