### PR TITLE
[Feat] API 상세 조회 시 조회수(viewCounts) 증가 로직 추가

### DIFF
--- a/src/main/java/com/umc/apiwiki/domain/api/entity/Api.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/entity/Api.java
@@ -56,4 +56,12 @@ public class Api extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private ProviderCompany providerCompany;
+
+    // 조회수 증가 로직
+    public void increaseViewCount() {
+        if (this.viewCounts == null) {
+            this.viewCounts = 0L;
+        }
+        this.viewCounts++;
+    }
 }

--- a/src/main/java/com/umc/apiwiki/domain/api/service/query/ApiDetailQueryService.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/service/query/ApiDetailQueryService.java
@@ -23,12 +23,15 @@ public class ApiDetailQueryService {
     private EntityManager em;
     private final UserFavoriteApiRepository favoriteRepository;
 
+    @Transactional
     public ApiResDTO.ApiDetail getApiDetail(Long apiId, Long userId) {
 
         Api api = em.find(Api.class, apiId);
         if (api == null) {
             throw new GeneralException(GeneralErrorCode.API_NOT_FOUND);
         }
+
+        api.increaseViewCount();
 
         // 좋아요 여부 확인 (userId가 null이면 false)
         boolean isFavorited = userId != null && favoriteRepository.existsByUserIdAndApiId(userId, apiId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closed #50

## #️⃣ 작업 내용

API 상세 조회(`GET /api/v1/apis/{apiId}`) 시 조회수가 증가하지 않는 문제를 해결했습니다.
1. **Api Entity**: 조회수를 1 증가시키는 비즈니스 메서드 `increaseViewCount()` 추가
2. **ApiDetailQueryService**:
    * `getApiDetail` 메서드에 `@Transactional` 어노테이션을 추가하여 `readOnly = false`로 오버라이딩
    * 단순 조회 후 **JPA Dirty Checking(변경 감지)**을 통해 DB에 Update 쿼리가 발생하도록 수정

## #️⃣ 테스트 결과

* [x] 로컬 환경에서 API 상세 조회 호출 시 응답 정상 반환 확인
* [x] DB 확인 결과 `apis` 테이블의 `view_counts` 컬럼이 +1 증가하는 것 확인
* [x] 기존 조회 로직(카테고리 매핑 등) 사이드 이펙트 없음 확인

## #️⃣ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요? (직접 호출 테스트 완료)
* [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
* [x] 코드 컨벤션에 따라 코드를 작성했나요?
* [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

**[API 상세 조회를 3번 했을 때의 응답]**

```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "apiId": 2,
    "name": "Jira API",
    "summary": "이슈 추적 및 애자일 관리",
    "longDescription": null,
    "officialUrl": "https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/",
    "avgRating": 0,
    "viewCounts": 3, # 조회수가 3만큼 증가됨
    "categories": [
      {
        "categoryId": 3,
        "name": "개발"
      },
      {
        "categoryId": 4,
        "name": "프로젝트관리"
      }
    ],
    "logo": "data:image/...",
    "createdAt": "2026-01-26T23:17:00",
    "updatedAt": "2026-02-03T18:05:43.6550828",
    "isFavorited": false
  }
}
```

## #️⃣ 리뷰 요구사항 (선택)

* 기존에 놓쳤던 기능을 추가하였습니다.
* 트랜잭션 설정 변경(`readOnly` 해제) 및 더티 체킹 관련 위주로 확인 부탁드립니다!

