### PR TITLE
[Feat] 비용 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/apiwiki/domain/api/controller/ApiController.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/controller/ApiController.java
@@ -95,4 +95,17 @@ public class ApiController implements ApiControllerDocs{
                 GeneralSuccessCode.OK,
                 apiCommandService.toggleFavorite(userId, apiId)
         );
-    }}
+    }
+
+    @GetMapping("/{apiId}/pricing")
+    @Override
+    public ApiResponse<ApiResDTO.ApiPricing> getApiPricing(
+            @PathVariable Long apiId
+    ) {
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                apiDetailQueryService.getApiPricing(apiId)
+        );
+    }
+
+}

--- a/src/main/java/com/umc/apiwiki/domain/api/controller/ApiControllerDocs.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/controller/ApiControllerDocs.java
@@ -91,4 +91,22 @@ public interface ApiControllerDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long apiId
     );
+
+    @Operation(
+            summary = "API 비용 정보 조회 By 제인",
+            description = """
+                API 상세 - 비용정보 탭에서 사용할 데이터를 조회합니다.
+                
+                ▪ pricingInfoCsv는 DB에 저장된 CSV 텍스트를 반환합니다.
+                ▪ pricingType은 무료/혼합/유료 필터링 및 뱃지 용도입니다.
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "API 비용 정보 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "요청한 API를 찾을 수 없습니다. (API4001)")
+    })
+    @GetMapping("/apis/{apiId}/pricing")
+    ApiResponse<ApiResDTO.ApiPricing> getApiPricing(
+            @PathVariable Long apiId
+    );
 }

--- a/src/main/java/com/umc/apiwiki/domain/api/dto/ApiResDTO.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/dto/ApiResDTO.java
@@ -26,7 +26,7 @@ public class ApiResDTO {
             boolean isFavorited
     ) {}
 
-    // 상세 조회 DTO by 재인
+    // 상세 조회 DTO by 제인
     public record ApiDetail(
             Long apiId,
             String name,
@@ -52,5 +52,12 @@ public class ApiResDTO {
     public record FavoriteToggle(
             Long apiId,
             boolean isFavorited
+    ) {}
+
+    // 비용 정보 응답 DTO by 제인
+    public record ApiPricing(
+            Long apiId,
+            PricingType pricingType,
+            String pricingInfoCsv
     ) {}
 }

--- a/src/main/java/com/umc/apiwiki/domain/api/service/query/ApiDetailQueryService.java
+++ b/src/main/java/com/umc/apiwiki/domain/api/service/query/ApiDetailQueryService.java
@@ -64,4 +64,18 @@ public class ApiDetailQueryService {
                 isFavorited
         );
     }
+
+    // 비용 정보 탭 조회
+    public ApiResDTO.ApiPricing getApiPricing(Long apiId) {
+        Api api = em.find(Api.class, apiId);
+        if (api == null) {
+            throw new GeneralException(GeneralErrorCode.API_NOT_FOUND);
+        }
+
+        return new ApiResDTO.ApiPricing(
+                api.getId(),
+                api.getPricingType(),
+                api.getPricingInfo()
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #47 

## #️⃣ 작업 내용

- API 상세 페이지의 비용정보 탭 조회 API를 구현했습니다.
- /api/v1/apis/{apiId}/pricing 엔드포인트를 추가하여 pricingType과 pricingInfoCsv(CSV text)를 조회할 수 있도록 했습니다.
- 비용 정보는 요구사항에 따라 CSV 형식의 text 데이터를 가공 없이 그대로 반환합니다.
- 기존 ApiDetailQueryService 구조에 맞춰 조회 로직을 추가했습니다.
- 응답 DTO는 기존 API 응답 구조에 맞게 ApiResDTO에 추가했습니다.

## #️⃣ 테스트 결과

- 존재하는 API ID 조회 시 정상 응답 확인
- 존재하지 않는 API ID 요청 시 API_NOT_FOUND(API4001) 에러 반환 확인

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

pricingInfoCsv를 CSV text 그대로 반환하는 방식이 요구사항에 부합하는지 확인 부탁드립니다.