### PR TITLE
[Fix] 리뷰 삭제 불가능 문제 해결

### DIFF
--- a/src/main/java/com/umc/apiwiki/domain/community/dto/review/ApiReviewResDTO.java
+++ b/src/main/java/com/umc/apiwiki/domain/community/dto/review/ApiReviewResDTO.java
@@ -17,6 +17,7 @@ public class ApiReviewResDTO {
 
     // 개별 리뷰 응답 DTO
     public static record ReviewItem(
+            Long reviewId,
             String nickname,
             String comment,
             Float rating,
@@ -24,6 +25,7 @@ public class ApiReviewResDTO {
     ) {
         public static ReviewItem from(ApiReview review) {
             return new ReviewItem(
+                    review.getId(),
                     review.getUser().getNickname(),
                     review.getComment(),
                     review.getRating(),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#69 

## #️⃣ 작업 내용

리뷰 조회 API 응답에 각 리뷰의 식별자인 `reviewId`를 추가했습니다.
이를 통해 리뷰 목록 조회 후 삭제 API를 정상적으로 호출할 수 있도록 수정했습니다.

## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 리뷰 요구사항 (선택)

로컬 테스트는 수행하지 못했으며, 기존 리뷰 로직에는 영향이 없음을 코드 레벨에서 확인했습니다.
문제 없는지 확인 부탁드립니다.